### PR TITLE
Add simulate interaction function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,11 @@ version = "0.0.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 
 [compat]
 julia = "1.8"
+ModelingToolkit = ">=6.0.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/ChatThemAll.jl
+++ b/src/ChatThemAll.jl
@@ -2,6 +2,7 @@ module ChatThemAll
 
 # SECTION - Imports
 using Dates
+using ModelingToolkit
 
 # SECTION - Exports
 # export token, url, api_version, api_endpoint, channels, channel
@@ -17,5 +18,17 @@ include("module.jl")
 include("bot.jl")
 include("state.jl")
 include("hub.jl")
+
+# Function to simulate interaction with timing and delay sequences
+function simulate_interaction(interaction_time::Float64, delay_time::Float64)
+    @parameters t
+    @variables x(t)
+    D = Differential(t)
+    eqs = [D(x) ~ -x + interaction_time]
+    sys = ODESystem(eqs)
+    prob = ODEProblem(sys, [x => 0.0], (0.0, delay_time))
+    sol = solve(prob, Tsit5())
+    return sol
+end
 
 end

--- a/src/hub.jl
+++ b/src/hub.jl
@@ -47,6 +47,7 @@ function start!(hub::BotsHub, log_path=joinpath(pwd(), "log"))
             schedule(init(m))
             is_initialized(state(hub), module_name)
             write(f, "[$d] end init $module_name\n")
+            simulate_interaction(1.0, 0.5)
         end
     end
     close(f)

--- a/src/module.jl
+++ b/src/module.jl
@@ -26,6 +26,7 @@ struct ListeningModule <: AbstractModule
         name::String="Listening module",
         run::Union{Task,Nothing}=nothing
     )
+        simulate_interaction(1.0, 0.5)
         return new(init, name, run)
     end
 end
@@ -40,6 +41,7 @@ struct MonitoringModule <: AbstractModule
         name::String="Monitoring module",
         run::Union{Task,Nothing}=nothing
     )
+        simulate_interaction(1.0, 0.5)
         return new(init, name, run)
     end
 end
@@ -54,6 +56,7 @@ struct ExecutionModule <: AbstractModule
         name::String="Execution module",
         run::Union{Task,Nothing}=nothing
     )
+        simulate_interaction(1.0, 0.5)
         return new(init, name, run)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,4 +3,10 @@ using Test
 
 @testset "ChatThemAll.jl" begin
     # Write your tests here.
+    @testset "simulate_interaction" begin
+        interaction_time = 1.0
+        delay_time = 0.5
+        sol = simulate_interaction(interaction_time, delay_time)
+        @test sol[end] ≈ interaction_time
+    end
 end


### PR DESCRIPTION
Add functionality for chatbots to interact with appropriate timing and delay sequences using `ChatThemAll.jl` and `ModelingToolkit.jl`.

* **Project.toml**
  - Add `ModelingToolkit` to `[deps]` and `[compat]` sections.

* **src/ChatThemAll.jl**
  - Import `ModelingToolkit`.
  - Add `simulate_interaction` function to handle timing and delay sequences.

* **src/module.jl**
  - Add `simulate_interaction` function call in `ListeningModule`, `MonitoringModule`, and `ExecutionModule`.

* **src/hub.jl**
  - Add `simulate_interaction` function call in `start!` function.

* **test/runtests.jl**
  - Add tests for `simulate_interaction` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mducko/ChatThemAll.jl/pull/1?shareId=9a30947f-c364-48b7-9e14-3343327b1f83).